### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @luisfcolon


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `@luisfcolon` as the default owner for all files.